### PR TITLE
Add back core:loaded-shell-environment hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "atom-languageclient": "0.2.0",
     "flow-language-server": "^0.1.5"
   },
+  "activationHooks": [
+    "core:loaded-shell-environment"
+  ],
   "consumedServices": {
     "status-bar": {
       "versions": {


### PR DESCRIPTION
I think this got lost in the move :D

Without this change, we try to spawn Node before Atom has a valid `$PATH`, which causes an ENOENT.