### PR TITLE
Add source.flow to grammar scopes

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -49,7 +49,7 @@ const BUSY_STATUS = Object.freeze({
 
 class FlowLanguageClient extends AutoLanguageClient {
   getGrammarScopes() {
-    return ['source.js', 'source.jsx', 'source.js.jsx'];
+    return ['source.js', 'source.jsx', 'source.js.jsx', 'source.flow'];
   }
 
   getLanguageName() {


### PR DESCRIPTION
Atom v1.32.0 [enabled a new file type parser by default](https://github.com/atom/atom/releases/tag/v1.32.0) which classifies files marked with the `@flow` pragma as "Flow JavaScript" (`source.flow`) rather than "JavaScript" (`source.js`).

This PR adds `source.flow` to the grammar scopes list, which closes #74. In the future, it would be cool if the scopes array was configurable (and I'd be happy to open a PR if it's desired functionality), but for now this gets `ide-flowtype` working again on `v1.32.0`.

P.S. Thanks for your hard work on this project!